### PR TITLE
1088 - Create episode - invalid data on publish date

### DIFF
--- a/src/frontend/static/js/podcastmanagement/episode-functions.js
+++ b/src/frontend/static/js/podcastmanagement/episode-functions.js
@@ -548,7 +548,9 @@ export function initEpisodeFunctions() {
       const data = Object.fromEntries(formData.entries());
 
       // Ensure recordingAt is in the correct format
-      if (data.recordingAt) {
+      if (data.recordingAt === '') {
+        data.recordingAt = null; // Set to null if no date is provided
+      } else if (data.recordingAt) {
         const recordingAt = new Date(data.recordingAt);
         if (isNaN(recordingAt.getTime())) {
           showNotification(


### PR DESCRIPTION
Error was on recordedAt being set to an empty string, but in schema it only allows None if no date is provided.