### PR TITLE
Remove text in account 

### DIFF
--- a/src/frontend/templates/account/account.html
+++ b/src/frontend/templates/account/account.html
@@ -34,9 +34,6 @@
         </svg>
         Back to Dashboard
       </a>
-      <div class="header-content">
-        <h1>Account Settings</h1>
-      </div>
     </div>
 
     <div class="account-settings-wrapper">


### PR DESCRIPTION
* deleted the header block that was rendering the “Account Settings” title.