### PR TITLE
menu appears over page header when untoggled

### DIFF
--- a/src/Frontend/static/css/episode-to-do/episode-to-do.css
+++ b/src/Frontend/static/css/episode-to-do/episode-to-do.css
@@ -106,6 +106,7 @@ body {
 /* Header */
 .header {
   margin-bottom: 1.5rem;
+  z-index: 1;
 }
 
 .header-content {


### PR DESCRIPTION
* added z-index under the .header rule for the menu (with its higher default or assigned z-index) now cleanly slides over the header, preserving the intended layering and smooth transition.

