### PR TITLE
store text fix

### DIFF
--- a/src/frontend/static/js/store/store.js
+++ b/src/frontend/static/js/store/store.js
@@ -14,6 +14,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   
   await handlePurchaseSuccess();
   setupContinueShoppingButton();
+
+  const pageTitle = document.getElementById("page-title");
+  if (pageTitle) {
+    pageTitle.textContent = "Store"; // Set the page title
+  }
+
 });
 
 async function handlePurchaseSuccess() {


### PR DESCRIPTION
*  Added a small snippet to populate the header’s page‐title placeholder when the Store view loads