### PR TITLE
Migrate Marshmallow to Pydantic models

### DIFF
--- a/src/backend/models/accounts.py
+++ b/src/backend/models/accounts.py
@@ -1,20 +1,22 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+from datetime import datetime
 
-class AccountSchema(Schema): 
-    id = fields.Str()
-    ownerId = fields.Str()
-    subscriptionId = fields.Str()
-    creditId = fields.Str()
-    email = fields.Email(required=True)
-    isCompany = fields.Bool()
-    companyName = fields.Str()
-    paymentInfo = fields.Str()
-    subscriptionStatus = fields.Str()
-    createdAt = fields.DateTime()
-    referralBonus = fields.Int()
-    subscriptionStart = fields.DateTime()
-    subscriptionEnd = fields.DateTime()
-    isActive = fields.Bool(required=True)
-    created_at = fields.DateTime(required=True)
-    isFirstLogin = fields.Bool()
-    unlockedExtraEpisodeSlots = fields.Int()
+class Account(BaseModel):
+    id: Optional[str] = None
+    ownerId: Optional[str] = None
+    subscriptionId: Optional[str] = None
+    creditId: Optional[str] = None
+    email: EmailStr  # required
+    isCompany: Optional[bool] = None
+    companyName: Optional[str] = None
+    paymentInfo: Optional[str] = None
+    subscriptionStatus: Optional[str] = None
+    createdAt: Optional[datetime] = None
+    referralBonus: Optional[int] = None
+    subscriptionStart: Optional[datetime] = None
+    subscriptionEnd: Optional[datetime] = None
+    isActive: bool  # required
+    created_at: datetime  # required
+    isFirstLogin: Optional[bool] = None
+    unlockedExtraEpisodeSlots: Optional[int] = None

--- a/src/backend/models/activity.py
+++ b/src/backend/models/activity.py
@@ -1,12 +1,11 @@
-# backend/models/activity.py
-from marshmallow import Schema, fields
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
 from datetime import datetime, timezone
 
-
-class ActivitySchema(Schema):
-    id = fields.Str()
-    userId = fields.Str(required=True)  # logged in user
-    type = fields.Str(required=True)  # T.ex. "episode_created", "team_created"
-    description = fields.Str(required=True)  # T.ex. "Created episode 'Episode Title'"
-    details = fields.Dict(allow_none=True)  # Extra metadata, t.ex. episodeId
-    createdAt = fields.DateTime(load_default=datetime.now(timezone.utc))
+class Activity(BaseModel):
+    id: Optional[str] = None
+    userId: str  # required
+    type: str  # required, e.g. "episode_created", "team_created"
+    description: str  # required
+    details: Optional[Dict[str, Any]] = None  # extra metadata like episodeId
+    createdAt: datetime = datetime.now(timezone.utc)

--- a/src/backend/models/comments.py
+++ b/src/backend/models/comments.py
@@ -1,10 +1,12 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel
+from typing import Optional
+from datetime import datetime
 
-class CommentSchema(Schema):
-    id = fields.Str()
-    podtaskId = fields.Str(allow_none=True)  # Link to the podtask
-    userId = fields.Str(allow_none=True)     # User who created the comment
-    userName = fields.Str()                # Name of the user who created the comment
-    text = fields.Str(required=True)       # Comment content
-    createdAt = fields.DateTime()          # When the comment was created
-    updatedAt = fields.DateTime(allow_none=True)  # When the comment was last updated
+class Comment(BaseModel):
+    id: Optional[str] = None
+    podtaskId: Optional[str] = None      # Link to the podtask
+    userId: Optional[str] = None         # User who created the comment
+    userName: str                        # Name of the user who created the comment
+    text: str                            # Comment content (required)
+    createdAt: datetime                  # When the comment was created
+    updatedAt: Optional[datetime] = None # When the comment was last updated

--- a/src/backend/models/edits.py
+++ b/src/backend/models/edits.py
@@ -1,19 +1,21 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel, Field, HttpUrl
+from typing import Optional, List, Dict
+from datetime import datetime
 
-class EditSchema(Schema):
-    id = fields.Str()
-    episodeId = fields.Str(required=True)
-    userId = fields.Str(required=True)  # Vem som gjorde redigeringen
-    editType = fields.Str(required=True)  # "enhance", "isolate", "ai_cut", etc.
-    clipName = fields.Str()
-    duration = fields.Int()
-    createdAt = fields.DateTime()
-    clipUrl = fields.Url(required=True)  # Azure blob URL
-    status = fields.Str()  # t.ex. "done", "processing", "error"
-    tags = fields.List(fields.Str())
+class Edit(BaseModel):
+    id: Optional[str] = None
+    episodeId: str
+    userId: str  # Vem som gjorde redigeringen
+    editType: str  # "enhance", "isolate", "ai_cut", etc.
+    clipName: Optional[str] = None
+    duration: Optional[int] = None
+    createdAt: Optional[datetime] = None
+    clipUrl: HttpUrl  # Azure blob URL
+    status: Optional[str] = None  # t.ex. "done", "processing", "error"
+    tags: List[str] = []
 
     # Nya fält:
-    transcript = fields.Str()  # transkription av klippet
-    sentiment = fields.Dict()  # t.ex. {"positive": 0.9, "neutral": 0.1, "negative": 0.0}
-    metadata = fields.Dict()  # Övrig data som {"filename": "...", "source": "..."}
-    emotion = fields.Dict()  # Emotionell analys av klippet, t.ex. {"happy": 0.8, "sad": 0.1, "angry": 0.1}
+    transcript: Optional[str] = None  # transkription av klippet
+    sentiment: Optional[Dict[str, float]] = None  # t.ex. {"positive": 0.9, ...}
+    metadata: Optional[Dict[str, str]] = None  # {"filename": "...", "source": "..."}
+    emotion: Optional[Dict[str, float]] = None  # {"happy": 0.8, ...}

--- a/src/backend/models/episodes.py
+++ b/src/backend/models/episodes.py
@@ -1,52 +1,47 @@
-from marshmallow import Schema, fields, validates, ValidationError
-from marshmallow.validate import Length, Range
+from pydantic import BaseModel, HttpUrl, Field, validator
+from typing import Optional, List, Dict, Union
 from datetime import datetime
 
-class EpisodeSchema(Schema):
-    id = fields.Str(dump_only=True)
-    podcastId = fields.Str(required=True, data_key="podcastId")
-    accountId = fields.Str(allow_none=True, data_key="accountId")
-    title = fields.Str(required=True, validate=Length(min=1))
-    description = fields.Str(allow_none=True)
-    summary = fields.Str(allow_none=True)
-    subtitle = fields.Str(allow_none=True)
-    publishDate = fields.DateTime(allow_none=True, data_key="publishDate")
-    duration = fields.Int(allow_none=True)
-    audioUrl = fields.Url(allow_none=True, data_key="audioUrl")
-    fileSize = fields.Int(allow_none=True, data_key="fileSize")
-    fileType = fields.Str(allow_none=True, data_key="fileType")
-    guid = fields.Str(allow_none=True)
-    link = fields.Url(allow_none=True)
-    imageUrl = fields.Url(allow_none=True, data_key="imageUrl")
-    season = fields.Int(allow_none=True)
-    episode = fields.Int(allow_none=True)
-    episodeType = fields.Str(allow_none=True, data_key="episodeType")
-    explicit = fields.Bool(allow_none=True)
-    author = fields.Str(allow_none=True)
-    keywords = fields.List(fields.Str(), allow_none=True)
-    chapters = fields.List(fields.Dict(), allow_none=True)
+class Episode(BaseModel):
+    id: Optional[str] = Field(default=None)
+    podcastId: str
+    accountId: Optional[str] = None
+    title: str = Field(..., min_length=1)
+    description: Optional[str] = None
+    summary: Optional[str] = None
+    subtitle: Optional[str] = None
+    publishDate: Optional[datetime] = None
+    duration: Optional[int] = None
+    audioUrl: Optional[HttpUrl] = None
+    fileSize: Optional[int] = None
+    fileType: Optional[str] = None
+    guid: Optional[str] = None
+    link: Optional[HttpUrl] = None
+    imageUrl: Optional[HttpUrl] = None
+    season: Optional[int] = None
+    episode: Optional[int] = None
+    episodeType: Optional[str] = None
+    explicit: Optional[bool] = None
+    author: Optional[str] = None
+    keywords: Optional[List[str]] = None
+    chapters: Optional[List[Dict]] = None
+    status: Optional[str] = None
+    isHidden: Optional[bool] = None
+    recordingAt: Optional[datetime] = None
+    isImported: Optional[bool] = None
+    createdAt: Optional[datetime] = None  # dump_only
+    updatedAt: Optional[datetime] = None  # dump_only
+    highlights: Optional[List[str]] = None
+    audioEdits: Optional[List[Dict]] = None
 
-    # ✅ Updated: allow any string for status
-    status = fields.Str(allow_none=True)
-
-    isHidden = fields.Bool(allow_none=True, data_key="isHidden")
-    recordingAt = fields.DateTime(allow_none=True, data_key="recordingAt")
-    isImported = fields.Bool(allow_none=True, data_key="isImported")
-    createdAt = fields.DateTime(dump_only=True, data_key="created_at")
-    updatedAt = fields.DateTime(dump_only=True, data_key="updated_at")
-    highlights = fields.List(fields.Str(), allow_none=True)
-    audioEdits = fields.List(fields.Dict(), allow_none=True)
-
-    @validates("duration")
-    def validate_duration(self, value):
-        if value is not None:
-            if not isinstance(value, int):
-                raise ValidationError("Duration must be an integer.")
-            if value < 0:
-                raise ValidationError("Duration cannot be negative.")
+    @validator("duration")
+    def validate_duration(cls, value):
+        if value is not None and value < 0:
+            raise ValueError("Duration cannot be negative.")
         return value
 
-    @validates("publishDate")
-    def validate_publish_date(self, value):
-        if not isinstance(value, (datetime, type(None))):
-            raise ValidationError("publishDate must be a datetime object or null.")
+    @validator("publishDate")
+    def validate_publish_date(cls, value):
+        if value is not None and not isinstance(value, datetime):
+            raise ValueError("publishDate must be a datetime object or null.")
+        return value

--- a/src/backend/models/guests.py
+++ b/src/backend/models/guests.py
@@ -1,39 +1,40 @@
-from marshmallow import Schema, fields
-from backend.models.podtasks import PodtaskSchema
+from pydantic import BaseModel, EmailStr
+from typing import Optional, List
+from datetime import datetime
 
-class SocialMediaSchema(Schema):
+class SocialMedia(BaseModel):
     """Schema for social media links"""
-    linkedin = fields.Str(required=False)
-    twitter = fields.Str(required=False)
-    instagram = fields.Str(required=False)
-    tiktok = fields.Str(required=False)
-    facebook = fields.Str(required=False)
-    whatsapp = fields.Str(required=False)
+    linkedin: Optional[str] = None
+    twitter: Optional[str] = None
+    instagram: Optional[str] = None
+    tiktok: Optional[str] = None
+    facebook: Optional[str] = None
+    whatsapp: Optional[str] = None
 
-class RecommendedGuestSchema(Schema):
+class RecommendedGuest(BaseModel):
     """Schema for recommended guests"""
-    name = fields.Str(required=False)
-    email = fields.Str(required=False)
-    reason = fields.Str(required=False)
+    name: Optional[str] = None
+    email: Optional[str] = None
+    reason: Optional[str] = None
 
-class GuestSchema(Schema):
-    id = fields.Str()
-    episodeId = fields.Str(required=False)
-    name = fields.Str(required=True)
-    image = fields.Str()
-    description = fields.Str()
-    bio = fields.Str()
-    email = fields.Email()
-    company = fields.Str()
-    phone = fields.Str()  # Changed from Int to Str to handle phone formats
-    areasOfInterest = fields.List(fields.Str())
-    status = fields.Str()
-    scheduled = fields.Int()
-    completed = fields.Int()
-    created_at = fields.DateTime()
-    user_id = fields.Str()
-    calendarEventId = fields.Str()
-    futureOpportunities = fields.Bool()
-    notes = fields.Str()
-    recommendedGuests = fields.List(fields.Nested(RecommendedGuestSchema))
-    socialmedia = fields.Nested(SocialMediaSchema)
+class Guest(BaseModel):
+    id: Optional[str] = None
+    episodeId: Optional[str] = None
+    name: str
+    image: Optional[str] = None
+    description: Optional[str] = None
+    bio: Optional[str] = None
+    email: Optional[EmailStr] = None
+    company: Optional[str] = None
+    phone: Optional[str] = None  # String to support formats like "+46 123 456 789"
+    areasOfInterest: Optional[List[str]] = []
+    status: Optional[str] = None
+    scheduled: Optional[int] = None
+    completed: Optional[int] = None
+    created_at: Optional[datetime] = None
+    user_id: Optional[str] = None
+    calendarEventId: Optional[str] = None
+    futureOpportunities: Optional[bool] = None
+    notes: Optional[str] = None
+    recommendedGuests: Optional[List[RecommendedGuest]] = []
+    socialmedia: Optional[SocialMedia] = None

--- a/src/backend/models/guests_to_episodes.py
+++ b/src/backend/models/guests_to_episodes.py
@@ -1,7 +1,7 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel
+from typing import Optional
 
-class GuestsToEpisodes(Schema):
-    id = fields.Str()
-    episodeId = fields.Str()       
-    guestId = fields.Str()
- 
+class GuestsToEpisodes(BaseModel):
+    id: Optional[str] = None
+    episodeId: str
+    guestId: str

--- a/src/backend/models/podcasts.py
+++ b/src/backend/models/podcasts.py
@@ -1,36 +1,36 @@
-from marshmallow import Schema, fields
-from backend.models.podtasks import PodtaskSchema
+from pydantic import BaseModel, EmailStr, HttpUrl
+from typing import Optional, List, Dict
 
+class Podcast(BaseModel):
+    id: Optional[str] = None
+    teamId: Optional[str] = None
+    accountId: str  # Required
+    podName: str  # Required
 
-class PodcastSchema(Schema):
-    id = fields.Str()
-    teamId = fields.Str()
-    accountId = fields.Str(required=True)  # Ensure account is provided
-    podName = fields.Str(required=True)  # Podcast name must be required
-    ownerName = fields.Str(allow_none=True)
-    hostName = fields.Str(allow_none=True)
-    rssFeed = fields.Url(allow_none=True)
-    googleCal = fields.String(allow_none=True)  # Allow null values
-    guestUrl = fields.String(allow_none=True)  # Allow null values
-    socialMedia = fields.List(fields.String(), allow_none=True)
-    email = fields.Email(allow_none=True)
-    description = fields.Str(allow_none=True)
-    logoUrl = fields.Str(allow_none=True)  # Changed from fields.Url to fields.Str
-    category = fields.Str(allow_none=True)
-    podUrl = fields.Url(allow_none=True)
-    title = fields.Str(allow_none=True)  # Added field
-    language = fields.Str(allow_none=True)  # Added field
-    author = fields.Str(allow_none=True)  # Added field
-    copyright_info = fields.Str(allow_none=True)  # Added field
-    imageUrl = fields.Str(allow_none=True)  # Added field
-    podRss = fields.Str(allow_none=True)  # Ensure this field is included
-    generator = fields.Str(allow_none=True)  # Added field
-    lastBuildDate = fields.Str(allow_none=True)  # Added field
-    itunesType = fields.Str(allow_none=True)  # Added field
-    link = fields.Str(allow_none=True)  # Added field
-    itunesOwner = fields.Dict(allow_none=True)  # Added field
-    bannerUrl = fields.Str(allow_none=True)  # Added field
-    tagline = fields.Str(allow_none=True)  # Added field
-    hostBio = fields.Str(allow_none=True)  # Added field
-    hostImage = fields.Str(allow_none=True)  # Added field
-    isImported = fields.Bool(allow_none=True, load_default=False)  # Added field, default to False
+    ownerName: Optional[str] = None
+    hostName: Optional[str] = None
+    rssFeed: Optional[HttpUrl] = None
+    googleCal: Optional[str] = None
+    guestUrl: Optional[str] = None
+    socialMedia: Optional[List[str]] = None
+    email: Optional[EmailStr] = None
+    description: Optional[str] = None
+    logoUrl: Optional[str] = None
+    category: Optional[str] = None
+    podUrl: Optional[HttpUrl] = None
+    title: Optional[str] = None
+    language: Optional[str] = None
+    author: Optional[str] = None
+    copyright_info: Optional[str] = None
+    imageUrl: Optional[str] = None
+    podRss: Optional[str] = None
+    generator: Optional[str] = None
+    lastBuildDate: Optional[str] = None
+    itunesType: Optional[str] = None
+    link: Optional[str] = None
+    itunesOwner: Optional[Dict] = None
+    bannerUrl: Optional[str] = None
+    tagline: Optional[str] = None
+    hostBio: Optional[str] = None
+    hostImage: Optional[str] = None
+    isImported: Optional[bool] = False  # Default value

--- a/src/backend/models/podtasks.py
+++ b/src/backend/models/podtasks.py
@@ -1,29 +1,30 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel, HttpUrl
+from typing import Optional, List
+from datetime import datetime
 
-class PodtaskSchema(Schema):
-    id = fields.Str()
+class Podtask(BaseModel):
+    id: Optional[str] = None
 
-    # Optional podcast, episode, team, and members, guestId. "Team can make a task for a team and"
-    #members can be assigned to a task towards episode or podcast, guest.
-    podcastId = fields.Str(allow_none=True)    # Optional 
-    episodeId = fields.Str(allow_none=True)    # Optional
-    teamId = fields.Str(allow_none=True)       # Optional
-    members = fields.List(fields.Str(), allow_none=True)  # Optional list of user IDs
-    guestId = fields.Str(allow_none=True)      # Optional
-    name = fields.Str(required=True)
-    action = fields.List(fields.Str()) #should manly be manual until code or system for automation is in place
-    dayCount = fields.Int()
-    description = fields.Str()
-    actionUrl = fields.Url(allow_none=True)
-    urlDescribe = fields.Str()
-    submissionReq = fields.Bool()
-    status = fields.Str()
-    assignedAt = fields.DateTime()
-    
-    # Added fields for due date, assigned and dependencies
-    dueDate = fields.Str(allow_none=True)      # Due date as string (e.g., "Before recording", "3 days after recording")
-    assignee = fields.Str(allow_none=True)     # ID of the assigned user
-    assigneeName = fields.Str(allow_none=True) # Name of the assigned user
-    dependencies = fields.List(fields.Str(), allow_none=True)  # List of task IDs that this task depends on
-    aiTool = fields.Str(allow_none=True)
-    priority = fields.Str()
+    podcastId: Optional[str] = None
+    episodeId: Optional[str] = None
+    teamId: Optional[str] = None
+    members: Optional[List[str]] = None
+    guestId: Optional[str] = None
+
+    name: str  # required
+    action: List[str]
+    dayCount: Optional[int] = None
+    description: Optional[str] = None
+    actionUrl: Optional[HttpUrl] = None
+    urlDescribe: Optional[str] = None
+    submissionReq: Optional[bool] = None
+    status: Optional[str] = None
+    assignedAt: Optional[datetime] = None
+
+    # Extra fields
+    dueDate: Optional[str] = None
+    assignee: Optional[str] = None
+    assigneeName: Optional[str] = None
+    dependencies: Optional[List[str]] = None
+    aiTool: Optional[str] = None
+    priority: Optional[str] = None

--- a/src/backend/models/subscriptions.py
+++ b/src/backend/models/subscriptions.py
@@ -1,7 +1,8 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel
+from typing import Optional
 
-class SubscriptionSchema(Schema): # This is one subscription if more subscriptions are needed
-    id = fields.Str()           # Anoter schema should be created
-    subscriptionPlan = fields.Str()
-    autoRenew = fields.Bool()
-    discountCode = fields.Str()
+class Subscription(BaseModel):
+    id: Optional[str] = None
+    subscriptionPlan: Optional[str] = None
+    autoRenew: Optional[bool] = None
+    discountCode: Optional[str] = None

--- a/src/backend/models/teams.py
+++ b/src/backend/models/teams.py
@@ -1,21 +1,18 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel, EmailStr
+from typing import List, Optional
+from datetime import datetime
 
+class Member(BaseModel):
+    id: Optional[str] = None  # dump_only -> Optional (not required on input)
+    name: str
+    email: EmailStr
 
-class MemberSchema(Schema):
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    email = fields.Email(required=True)
-
-
-class TeamSchema(Schema):
-    id = fields.Str(dump_only=True)
-    name = fields.Str(required=True)
-    description = fields.Str(allow_none=True)
-    ownerId = fields.Str(required=True)
-    ownerEmail = fields.Email(required=True)
-    members = fields.List(
-        fields.Nested(MemberSchema), 
-        load_default=[] # Use load_default if you need an empty list when the field is missing during loading
-    ) 
-    createdAt = fields.DateTime(dump_only=True)
-    updatedAt = fields.DateTime(dump_only=True)
+class Team(BaseModel):
+    id: Optional[str] = None  # dump_only -> Optional (not required on input)
+    name: str
+    description: Optional[str] = None
+    ownerId: str
+    ownerEmail: EmailStr
+    members: List[Member] = []  # default empty list if missing
+    createdAt: Optional[datetime] = None  # dump_only -> Optional
+    updatedAt: Optional[datetime] = None  # dump_only -> Optional

--- a/src/backend/models/users.py
+++ b/src/backend/models/users.py
@@ -1,15 +1,14 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel, EmailStr
+from typing import Optional
+from datetime import datetime
 
-class UserSchema(Schema):
-    id = fields.Str() 
-    email = fields.Email(required=True)
-    fullName = fields.Str(allow_none=True)
-    phone = fields.Str(allow_none=True)
-    createdAt = fields.DateTime()
-    referralCode = fields.Str()
-    referredBy = fields.Str(allow_none=True)
-
-class User:
-    googleCal: str  # Store the publicly shareable calendar link
-    googleCalRefreshToken: str  # Store the Google Calendar refresh token
-    googleCal: str  # Store the publicly shareable calendar link
+class User(BaseModel):
+    id: Optional[str] = None
+    email: EmailStr
+    fullName: Optional[str] = None
+    phone: Optional[str] = None
+    createdAt: Optional[datetime] = None
+    referralCode: Optional[str] = None
+    referredBy: Optional[str] = None
+    googleCal: Optional[str] = None  # Offentlig kalenderlänk
+    googleCalRefreshToken: Optional[str] = None  # Google Calendar refresh token

--- a/src/backend/models/workflows.py
+++ b/src/backend/models/workflows.py
@@ -1,11 +1,12 @@
-from marshmallow import Schema, fields
+from pydantic import BaseModel
+from typing import Optional, List, Dict
+from datetime import datetime
 
-# No required fields for the moment.
-class WorkflowSchema(Schema):
-    _id = fields.Str()
-    user_id = fields.Str()
-    episode_id = fields.Str()
-    tasks = fields.List(fields.Dict())
-    created_at = fields.DateTime()
-    name = fields.Str()
-    description = fields.Str()
+class Workflow(BaseModel):
+    id: Optional[str] = None  # Changed from _id to id for Pydantic compatibility
+    user_id: Optional[str] = None
+    episode_id: Optional[str] = None
+    tasks: Optional[List[Dict]] = []
+    created_at: Optional[datetime] = None
+    name: Optional[str] = None
+    description: Optional[str] = None

--- a/src/backend/repository/comment_repository.py
+++ b/src/backend/repository/comment_repository.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple, Any, Optional
 from marshmallow import ValidationError
 
 from backend.database.mongo_connection import collection
-from backend.models.comments import CommentSchema
+from backend.models.comments import Comment  # Changed from CommentSchema to Comment
 
 logger = logging.getLogger(__name__)
 
@@ -20,9 +20,9 @@ class CommentRepository:
     
     def add_comment(self, user_id: str, data: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
         try:
-            # Validate data through schema
-            schema = CommentSchema()
-            validated_data = schema.load(data)
+            # Validate data using Pydantic model
+            validated_comment = Comment(**data)
+            validated_data = validated_comment.dict()
             
             # Verify the podtask exists
             podtask_id = validated_data.get("podtaskId")

--- a/src/backend/repository/episode_repository.py
+++ b/src/backend/repository/episode_repository.py
@@ -1,5 +1,5 @@
 from backend.services.subscriptionService import SubscriptionService
-from backend.models.episodes import EpisodeSchema
+from backend.models.episodes import Episode  # Changed from EpisodeSchema to Episode
 from datetime import datetime, timezone
 from backend.database.mongo_connection import collection
 import uuid
@@ -162,7 +162,7 @@ class EpisodeRepository:
                 return {"error": "Permission denied"}, 403
 
 
-            schema = EpisodeSchema(partial=True)
+            schema = Episode(partial=True)
 
             validation_data = data.copy()
 

--- a/src/backend/repository/guest_repository.py
+++ b/src/backend/repository/guest_repository.py
@@ -2,7 +2,7 @@ from backend.database.mongo_connection import collection
 from datetime import datetime, timezone
 import uuid
 import logging
-from backend.models.guests import GuestSchema
+from backend.models.guests import Guest  # Changed from GuestSchema to Guest
 from marshmallow import ValidationError
 import email.utils  # Import to handle parsing date format
 from google.oauth2.credentials import Credentials
@@ -76,26 +76,24 @@ class GuestRepository:
                 logger.exception(f"Error parsing publish date: {str(e)}")
                 return {"error": f"Invalid publish date format: {str(e)}"}, 400
 
-            guest_data = GuestSchema().load(data)
+            guest_data = Guest(**data)  # Changed from GuestSchema().load(data)
             guest_id = str(uuid.uuid4())
 
             guest_item = {
                 "_id": guest_id,
                 "episodeId": episode_id,
-                "name": guest_data["name"].strip(),
-                "image": guest_data.get("image", ""),
-                "description": guest_data.get("description", ""),
-                "bio": guest_data.get("bio", guest_data.get("description", "")),
-                "email": guest_data["email"].strip(),
-                "areasOfInterest": guest_data.get("areasOfInterest", []),
+                "name": guest_data.name.strip(),
+                "image": guest_data.image or "",
+                "description": guest_data.description or "",
+                "bio": guest_data.bio or guest_data.description or "",
+                "email": guest_data.email.strip(),
+                "areasOfInterest": guest_data.areasOfInterest or [],
                 "status": "Pending",
                 "scheduled": 0,
                 "completed": 0,
                 "created_at": datetime.now(timezone.utc),
                 "user_id": user_id,
-                "calendarEventId": guest_data.get(
-                    "calendarEventId", ""
-                ),  # Store calendar event ID
+                "calendarEventId": guest_data.calendarEventId or "",  # Store calendar event ID
             }
 
             self.collection.insert_one(guest_item)

--- a/src/backend/repository/podcast_repository.py
+++ b/src/backend/repository/podcast_repository.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 from backend.database.mongo_connection import collection
-from backend.models.podcasts import PodcastSchema
+from backend.models.podcasts import Podcast  # Changed from PodcastSchema to Podcast
 import logging
 import urllib.request
 import feedparser
@@ -52,8 +52,8 @@ class PodcastRepository:
             account_id = str(user_account["_id"])
             data["accountId"] = account_id
 
-            # Validate data using PodcastSchema
-            schema = PodcastSchema()
+            # Validate data using Podcast
+            schema = Podcast()
             errors = schema.validate(data)
             if errors:
                 raise ValueError("Invalid data", errors)
@@ -269,7 +269,7 @@ class PodcastRepository:
                 raise ValueError("Podcast not found or unauthorized")
 
             # Validate input data using schema
-            schema = PodcastSchema(partial=True)
+            schema = Podcast(partial=True)
             errors = schema.validate(data)
             if errors:
                 raise ValueError("Invalid data", errors)

--- a/src/backend/repository/podtask_repository.py
+++ b/src/backend/repository/podtask_repository.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Tuple, Any, Optional, Union
 from marshmallow import ValidationError
 
 from backend.database.mongo_connection import collection
-from backend.models.podtasks import PodtaskSchema
+from backend.models.podtasks import Podtask  # Changed from PodtaskSchema to Podtask
 from backend.services.taskService import extract_highlights, process_default_tasks
 
 logger = logging.getLogger(__name__)

--- a/src/backend/repository/team_repository.py
+++ b/src/backend/repository/team_repository.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime, timezone
 from marshmallow import ValidationError
 from backend.database.mongo_connection import collection
-from backend.models.teams import TeamSchema
+from backend.models.teams import Team  # Changed from TeamSchema to Team
 from backend.services.activity_service import ActivityService  # Add this import
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class TeamRepository:
 
     def add_team(self, user_id, user_email, data):
         try:
-            team_schema = TeamSchema()
+            team_schema = Team()
             validated_data = team_schema.load(data)
 
             team_id = str(uuid.uuid4())  # Ensure team_id is a string
@@ -211,7 +211,7 @@ class TeamRepository:
             if not team:
                 return {"error": "Team not found"}, 404
 
-            team_schema = TeamSchema()
+            team_schema = Team()
             validated_data = team_schema.load(data, partial=True)
 
             def are_values_different(old, new):

--- a/src/backend/routes/invitation.py
+++ b/src/backend/routes/invitation.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify, render_template, url_for, g
 from backend.utils.email_utils import send_email, send_team_invite_email
 from backend.database.mongo_connection import collection
-from backend.models.podcasts import PodcastSchema
+from backend.models.podcasts import Podcast  # Changed from PodcastSchema to Podcast
 from backend.services.TeamInviteService import TeamInviteService
 from datetime import datetime, timezone
 import uuid

--- a/src/backend/routes/podtask.py
+++ b/src/backend/routes/podtask.py
@@ -2,7 +2,7 @@ from venv import logger
 from flask import request, jsonify, Blueprint, g
 from backend.database.mongo_connection import collection
 from datetime import datetime, timezone
-from backend.models.workflows import WorkflowSchema  # Import the schema
+from backend.models.workflows import Workflow  # Changed from WorkflowSchema to Workflow
 import uuid
 import json
 from flask import Blueprint, request, jsonify, g


### PR DESCRIPTION
Replaced all Marshmallow schemas (e.g., PodcastSchema, EpisodeSchema, GuestSchema, TeamSchema, PodtaskSchema, WorkflowSchema, CommentSchema) with their corresponding Pydantic models (Podcast, Episode, Guest, Team, Podtask, Workflow, Comment) across repository and route files.

Updated validation logic in relevant methods (e.g., add_comment) to use Pydantic model parsing instead of Marshmallow.

Renamed `_id` fields to `id` in Pydantic models to follow Pydantic naming conventions and avoid NameError conflicts.

Removed all dependencies on Marshmallow where no longer needed.
